### PR TITLE
Add insert option to control nvim_put paste

### DIFF
--- a/doc/uuid-nvim.txt
+++ b/doc/uuid-nvim.txt
@@ -24,6 +24,7 @@ You can set up the plugin using the following fields:
 
 - case:        string|nil The case of the UUID; "lower" or "upper".
 - quotes:      string|nil The type of quotes; "double", "single", or "none".
+- insert:      string|nil Puts the UUID either "after" or "before" cursor.
 - prefix:      string|nil The prefix to prepend to the UUID.
 - suffix:      string|nil The suffix to append to the UUID.
 - templates:   table|nil  The templates used to generate UUIDs.

--- a/lua/uuid-nvim/init.lua
+++ b/lua/uuid-nvim/init.lua
@@ -9,6 +9,7 @@
 local uuid_nvim_setup = {
   case = "lower",
   quotes = "double",
+  insert = "after",
   prefix = "",
   suffix = "",
   templates = {
@@ -33,6 +34,11 @@ local function validate_config(config)
   local valid_quotes = { double = true, single = true, none = true }
   if config.quotes and not valid_quotes[config.quotes] then
     error("Invalid 'quotes' value. Must be 'double', 'single', or 'none'.")
+  end
+
+  local valid_insert_options = { before = true, after = true }
+  if config.insert and not valid_insert_options[config.insert] then
+    error("Invalid 'insert' value. Must be 'before' or 'after'.")
   end
 
   if config.prefix and type(config.prefix) ~= "string" then
@@ -112,8 +118,9 @@ end
 --- @param opts UuidNvimSetup configuration overrides
 M.insert_v4 = function(opts)
   local uuid = M.get_v4(opts)
+  local after = uuid_nvim_setup.insert == "after"
 
-  vim.api.nvim_put({ uuid }, "c", true, true)
+  vim.api.nvim_put({ uuid }, "c", after, true)
 end
 
 M.toggle_highlighting = function()


### PR DESCRIPTION
Currently this always inserts after the cursor position which is less than ideal when doing something like `ci'` to edit a UUID. Added the option to modify the nvim_put after flag, but defaulted to current behavior.

See `h: nvim_put`.